### PR TITLE
alterando o github action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,11 +28,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }} 
         
-    - name: SonarCloud Scan
-      env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      uses: SonarSource/sonarcloud-github-action@v1.6
+    
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test


### PR DESCRIPTION
Removendo o SonarCloud da GitHubAction, para configurar a análise automática diretamente pelo site do SonarCloud.